### PR TITLE
positioner motion class update

### DIFF
--- a/pathlayer/lib/pathlayerstatic.klc
+++ b/pathlayer/lib/pathlayerstatic.klc
@@ -432,9 +432,6 @@ ROUTINE run
     --open layout file & load starting layer
     open_layout
 
-    --start extruder and enable laser
-    lam_start
-
     --loop layers
     REPEAT
       --set next layer
@@ -445,7 +442,9 @@ ROUTINE run
 
       --interlayer start logic
       --(i.e. pause, cool, rotate part)
-      interStartLayer
+      lam_start
+
+      DELAY(2000)
 
       --approach point
       `MOTION_OBJECT_NAME`__moveApproach

--- a/pathmotion/interfaces/positioner.motion.interface.klt
+++ b/pathmotion/interfaces/positioner.motion.interface.klt
@@ -160,8 +160,8 @@ ROUTINE new_cart(x,y,z,w,p,r : REAL; cnfg : CONFIG) : MOTION_DATA_TYPE
     ENDIF
     IF (`PATH_OBJECT_NAME`__get_idod = 1) THEN deg = (deg-180) ; ENDIF
     nde.pose = POS(x,y,z,w,p,r, cnfg) 
-    nde.pose.x = -1*nde.pose.x
-    nde.pose.r = -1*nde.pose.r
+    nde.pose.x = (Z_AXIS_DIR)*(-1)*nde.pose.x
+    nde.pose.r = (Z_AXIS_DIR)*(-1)*nde.pose.r
 
     arr[POSITION_JNT] = DEFAULT_POS_JNT
     arr[ROTARY_JNT] = ROT_DIRECTION*deg
@@ -224,10 +224,10 @@ ROUTINE tpath2pos(nde : t_TOOLPATH) : MOTION_DATA_TYPE
     p : MOTION_DATA_TYPE
   BEGIN
     deg = ATAN2(nde.v.y, nde.v.x)
-    IF (`PATH_OBJECT_NAME`__get_idod = 1) THEN deg = (deg-180) ; ENDIF
+    -- IF (`PATH_OBJECT_NAME`__get_idod = 1) THEN deg = (deg-180) ; ENDIF
     p.pose = nde.v
-    p.pose.x = -1*p.pose.x
-    p.pose.r = -1*p.pose.r
+    p.pose.x = (Z_AXIS_DIR)*(-1)*p.pose.x
+    p.pose.r = (Z_AXIS_DIR)*(-1)*p.pose.r
 
     arr[POSITION_JNT] = DEFAULT_POS_JNT
     arr[ROTARY_JNT] = ROT_DIRECTION*deg
@@ -415,7 +415,8 @@ ROUTINE approachPath(speed : REAL; stepSize : REAL; coordSys : INTEGER; idod : I
 %endif
 
     --get tangent from raster angle
-    tngt = VEC((-1*COS(rast.dir*rast.angle)),(SIN(rast.dir*rast.angle)),0)
+    -- tngt = VEC((-1*COS(rast.dir*rast.angle)),(SIN(rast.dir*rast.angle)),0)
+    tngt = VEC(-1,0,0)
 
     --move to offset -> to zero poisition
     `PATH_OBJECT_NAME`__makeline(spos, spos2, (ZEROPOS(1)), PTH_LINKING, PTH_LINETO, stepSize, speed, 1, tngt)
@@ -486,7 +487,8 @@ ROUTINE retractPath(speed : REAL; stepSize : REAL; coordSys : INTEGER; idod : IN
 %endif
 
     --get tangent from raster angle
-    tngt = VEC((-1*COS(rast.dir*rast.angle)),(SIN(rast.dir*rast.angle)),0)
+    -- tngt = VEC((-1*COS(rast.dir*rast.angle)),(SIN(rast.dir*rast.angle)),0)
+    tngt = VEC(-1,0,0)
 
     --move up from lpos to the retract height
     `PATH_OBJECT_NAME`__makeline(vpos1, vpos2, origin, PTH_LINKING, PTH_LINETO, stepSize, speed, 1, tngt)


### PR DESCRIPTION
- change powder to start after loading layers to save powder.
- direction of z-axis (in part or out of part) matters and has an effect on the motion planning. This is fixed in this pull request.